### PR TITLE
Update vu4.html

### DIFF
--- a/html/vu4.html
+++ b/html/vu4.html
@@ -27,7 +27,7 @@
 	<area shape="rect" coords="21,249,50,274" title="volume up" onclick="pressMenuRemote('115');">
 	<area shape="rect" coords="21,275,50,300" title="volume down" onclick="pressMenuRemote('114');">
 	<area shape="rect" coords="91,226,118,236" title="exit" onclick="pressMenuRemote('174');">
-	<area shape="rect" coords="21,226,48,236" title="epg" onclick="pressMenuRemote('358');">
+	<area shape="rect" coords="21,226,48,236" title="epg" onclick="pressMenuRemote('365');">
 	<area shape="rect" coords="90,249,119,274" title="channelup" onclick="pressMenuRemote('402');">
 	<area shape="rect" coords="90,275,119,300" title="channeldown" onclick="pressMenuRemote('403');">
 	<area shape="rect" coords="91,165,118,236," title="menu" onclick="pressMenuRemote('139');">
@@ -35,7 +35,7 @@
 	<area shape="rect" coords="60,249,80,260" title="audio" onclick="pressMenuRemote('392');">
 	<area shape="rect" coords="60,269,80,280" title="mute" onclick="pressMenuRemote('113');">
 	<area shape="rect" coords="60,290,80,301" title="timer edit" onclick="pressMenuRemote('176');">
-	<area shape="rect" coords="100,40,120,50" title="help" onclick="pressMenuRemote('138');">
+	<area shape="rect" coords="100,40,120,50" title="help" onclick="pressMenuRemote('358');">
 	<area shape="rect" coords="21,309,41,319" title="rewind" onclick="pressMenuRemote('168');">
 	<area shape="rect" coords="47,309,67,319" title="play" onclick="pressMenuRemote('207');">
 	<area shape="rect" coords="73,309,93,319" title="pause" onclick="pressMenuRemote('119');">


### PR DESCRIPTION
> Huevos: We are not changing the button mapping on Vu remotes.
Thats was for 6.4 Images, right?

I hope this here is for the 7.x Images - because it was wrong:
"epg" showed "info" - now ist shows the "epg".
"help" on Vu+ shows what on other remotes is "info".